### PR TITLE
Use doppler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,7 @@ jobs:
           name: Maybe publish to npm
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_EMAIL" | npm login
-              ./node_modules/.bin/publish
+              npm publish
             fi
 commands:
   add-npm-tokens:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
     jobs:
       - build:
           context:
-            - djd-ccc-deploy
+            - djd-npm-publish
 jobs:
   build:
     working_directory: ~/project
@@ -39,12 +39,9 @@ commands:
   add-npm-tokens:
     steps:
       - doppler-circleci/load_secrets:
-          doppler_token: DOPPLER_NPM_TOKEN
+          doppler_token: DOPPLER_TOKEN
       - run:
-          name: Add npm and Github tokens
+          name: Add npm token
           command: |
-            npm set @ft-interactive:registry=https://npm.pkg.github.com
             npm set @financial-times:registry=https://registry.npmjs.org
-            npm set @Financial-Times:registry=https://npm.pkg.github.com
-            npm set //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
             npm set //registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 orbs:
+  doppler-circleci: ft-circleci-orbs/doppler-circleci@1.4
   node: circleci/node@5.2.0
 workflows:
   version: 2
@@ -14,6 +15,8 @@ jobs:
       tag: '20.11-browsers'
     steps: 
       - checkout
+      - doppler-circleci/install
+      - add-npm-tokens
       - run:
           name: Install dependencies
           command: npm install
@@ -32,3 +35,16 @@ jobs:
               echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_EMAIL" | npm login
               ./node_modules/.bin/publish
             fi
+commands:
+  add-npm-tokens:
+    steps:
+      - doppler-circleci/load_secrets:
+          doppler_token: DOPPLER_NPM_TOKEN
+      - run:
+          name: Add npm and Github tokens
+          command: |
+            npm set @ft-interactive:registry=https://npm.pkg.github.com
+            npm set @financial-times:registry=https://registry.npmjs.org
+            npm set @Financial-Times:registry=https://npm.pkg.github.com
+            npm set //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+            npm set //registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ workflows:
   build:
     jobs: 
       - build
+          context: 
+            - djd-ccc-deploy
 jobs:
   build:
     working_directory: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,11 @@ orbs:
   doppler-circleci: ft-circleci-orbs/doppler-circleci@1.4
   node: circleci/node@5.2.0
 workflows:
-  version: 2
   build:
-    jobs: 
-      - build
-        context: 
-          - djd-ccc-deploy
+    jobs:
+      - build:
+          context:
+            - djd-ccc-deploy
 jobs:
   build:
     working_directory: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,25 @@ orbs:
   doppler-circleci: ft-circleci-orbs/doppler-circleci@1.4
   node: circleci/node@5.2.0
 workflows:
-  build:
+  version: 2
+  build-and-release:
     jobs:
-      - build:
+      - install:
+          filters: 
+            tags: 
+              only: /.*/
+      - release_npm:
           context:
             - djd-npm-publish
+          requires: 
+            - test
+          filters: 
+            tags: 
+              only: /^v.*/
+            branches: 
+              ignore: /.*/
 jobs:
-  build:
+  install:
     working_directory: ~/project
     executor:
       name: node/default
@@ -24,17 +36,24 @@ jobs:
       - run:
           name: ESLint
           command: ./node_modules/.bin/eslint -- .
+  release_npm: 
+    steps: 
       - run:
-          name: Compile with babel
-          command: npm run build
-      - store_artifacts:
-          path: dist/
+          name: Setup npm credentials
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc
       - run:
-          name: Maybe publish to npm
+          name: Generate build
+          command: npm run build        
+      - run:
+          name: Publish to NPM
           command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              npm publish
+            if [[ $CIRCLE_TAG =~ canary ]]
+            then
+              npm publish --access public --tag canary
+            else
+              npm publish --access public --tag latest
             fi
+
 commands:
   add-npm-tokens:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,34 +2,20 @@ version: 2.1
 orbs:
   doppler-circleci: ft-circleci-orbs/doppler-circleci@1.4
   node: circleci/node@5.2.0
-workflows:
-  version: 2
-  build-and-release:
-    jobs:
-      - install:
-          filters: 
-            tags: 
-              only: /.*/
-      - release_npm:
-          context:
-            - djd-npm-publish
-          requires: 
-            - test
-          filters: 
-            tags: 
-              only: /^v.*/
-            branches: 
-              ignore: /.*/
-jobs:
-  install:
-    working_directory: ~/project
+references:
+  default_container_config: &default_container_config
     executor:
       name: node/default
       tag: '20.11-browsers'
+  attach_workspace: &attach_workspace
+    attach_workspace:
+      at: ~/project
+jobs:
+  install:
+    <<: *default_container_config
     steps: 
       - checkout
       - doppler-circleci/install
-      - add-npm-tokens
       - run:
           name: Install dependencies
           command: npm install
@@ -37,10 +23,16 @@ jobs:
           name: ESLint
           command: ./node_modules/.bin/eslint -- .
   release_npm: 
+    <<: *default_container_config
     steps: 
+      - *attach_workspace
+      - doppler-circleci/load_secrets:
+          doppler_token: DOPPLER_TOKEN
       - run:
-          name: Setup npm credentials
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc
+          name: Add npm token
+          command: |
+            npm set @financial-times:registry=https://registry.npmjs.org
+            npm set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
       - run:
           name: Generate build
           command: npm run build        
@@ -53,14 +45,21 @@ jobs:
             else
               npm publish --access public --tag latest
             fi
-
-commands:
-  add-npm-tokens:
-    steps:
-      - doppler-circleci/load_secrets:
-          doppler_token: DOPPLER_TOKEN
-      - run:
-          name: Add npm token
-          command: |
-            npm set @financial-times:registry=https://registry.npmjs.org
-            npm set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+workflows:
+  version: 2
+  build-and-release:
+    jobs:
+      - install:
+          filters: 
+            tags: 
+              only: /.*/
+      - release_npm:
+          context:
+            - djd-npm-publish
+          requires: 
+            - install
+          filters: 
+            tags: 
+              only: /^v.*/
+            branches: 
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ workflows:
   build:
     jobs: 
       - build
-          context: 
-            - djd-ccc-deploy
+        context: 
+          - djd-ccc-deploy
 jobs:
   build:
     working_directory: ~/project

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ Plain object (optional).
 
 - `transform`: A function that takes in three arguments (`contentReference`, `annotation`, `label`) and returns a string. To use this feature, you should wrap your text in the following in your Google Doc text: ```[[[content reference]]] [[annotation | label]]```
 
+## Releasing
+
+First make sure your local is up to date with the origin and that you're on the `main` branch:
+
+```bash
+$ git pull
+$ git checkout main
+```
+
+Next, run `npm version [major|minor|patch]` to increment the version based on the type of changes in this release. We use [Semantic Versioning](https://semver.org/) to increment versions:
+
+- Breaking (non-backwards-compatible) changes should be a `major` release
+- New features (that are backwards-compatible) should be `minor`
+- Bug fixes should be a `patch`
+- Alternatively, you can use `npm version vX.X.X` to set the version yourself.
+
+Finally, run `git push --follow-tags` to push the new version to GitHub, which will trigger the CircleCI pipeline that publishes the new version on NPM.
 
 ## Licence
 This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
One thing to note is that I'm using the `djd-ccc-deploy` context since all I need are the npm secrets — not great practice, but I wonder if we should create a context that's just for deploying to npm that we use across lots of projects? Would be good to get thoughts... 